### PR TITLE
PCViz: Fixed the problem with "undefined" UniProt descriptions on node click

### DIFF
--- a/enzyme-portal/ep-website/src/main/webapp/resources/javascript/biojs/biojspcviz.custom.js
+++ b/enzyme-portal/ep-website/src/main/webapp/resources/javascript/biojs/biojspcviz.custom.js
@@ -41,7 +41,7 @@ $(document).ready(function() {
             onNodeClick: function(msg)  {
                 var annotation = msg.annotation;
                 var uniprotId = msg.uniprot ? msg.uniprot : annotation.geneUniprotMapping;
-                var summary = msg.uniprotdesc == null ? annotation.geneSummary : annotation.uniprotdesc;
+                var summary = msg.uniprotdesc == null ? annotation.geneSummary : msg.uniprotdesc;
                 var myContent =  "<table class='grid'>" +
                     "<tr><th>Gene</th><td>" + msg.id + "</td></tr>" +
                     "<tr><th>Aliases</th><td>" + annotation.geneAliases.replace(/:/g, ", ") + "</td></tr>" +


### PR DESCRIPTION
discovered this problem with the node descriptions (see the undefined msg below) while testing the widget on the dev server:

![screen shot 2015-03-21 at 7 49 36 pm](https://cloud.githubusercontent.com/assets/7809/6767394/73372454-d003-11e4-850f-088c78959106.png)

This simple change will fix the problem.

Thanks,
-- Arman